### PR TITLE
Split up dynamics from the state to avoid deepcopy overhead

### DIFF
--- a/mctslearn/__init__.py
+++ b/mctslearn/__init__.py
@@ -1,3 +1,6 @@
 from . import mcts
+from . import tree
+from . import dynamics
+from . import dynamics_registry
 
 __version__ = '0.0.1'

--- a/mctslearn/dynamics_registry.py
+++ b/mctslearn/dynamics_registry.py
@@ -1,0 +1,10 @@
+import gym
+from mctslearn.dynamics import EnvDynamics
+
+# TODO: Include some "has been reset flag" to get rid of warning
+cartpole_dynamics = EnvDynamics(
+    env_fn=lambda: gym.make('CartPole-v0'),
+    state_variable_names=[
+        ('env', 'state'),
+        '_elapsed_steps',
+    ])

--- a/mctslearn/tree.py
+++ b/mctslearn/tree.py
@@ -1,12 +1,13 @@
 import numpy as np
 
+
 class Node:
     """ Node in the tree we are searching """
 
     # FIXME: update arguments and set them
     def __init__(
             self,
-            env,
+            state,
             actions,
             parent=None,
             reward=0,
@@ -17,7 +18,7 @@ class Node:
     ):
         self.children = {}  # map from action to node
 
-        self.env = env
+        self.state = state
         self.actions = actions
         self.reward = reward
         self.parent = parent

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,20 +1,28 @@
+from copy import deepcopy
+
 import gym
 from mctslearn import mcts
+from mctslearn.dynamics_registry import cartpole_dynamics
+
+dynamics = cartpole_dynamics
 
 env = gym.make('CartPole-v0')
 
-episodes = 1
-state = env.reset()
+obs = env.reset()
+state = dynamics.env_to_state(env)
+state = deepcopy(state)
 
-agent = mcts.Agent(env, n_simulations=50)
-agent.set_start_state(state, env)
+episodes = 1
+
+agent = mcts.Agent(dynamics=dynamics, n_simulations=50)
+agent.set_start_state(obs, state)
 
 N = 100
 rs = []
 ts = []
 ss = []
 for _ in range(N):
-    a = agent.act(state, env)
+    a = agent.act(obs, obs)
     s, r, t, info = env.step(a)
     rs.append(r)
     ts.append(t)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import numpy as np
 import gym
 
-from mctslearn.env import EnvDynamics
+from mctslearn.dynamics import EnvDynamics
 
 
 def test_env_step():


### PR DESCRIPTION
This is a clean way to make the copying of states efficient.

It has code to wrap openai gym environments and specify what data in the state needs to be copied.

However, when attempting to solve cartpole with this there appears to be some inconsistencies in the search tree. Specifically the optimal path is worse when played out than in the search tree.